### PR TITLE
Features/add consume multiples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pacote PHP/Laravel para Consumir e Publicar Mensagens com RabbitMQ
+# Package PHP/Laravel to manager, consume and publish messages with AMQP / RabbitMQ
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/medeiroz/laravel-amqp-toolkit.svg?style=flat-square)](https://packagist.org/packages/medeiroz/laravel-amqp-toolkit)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/medeiroz/laravel-amqp-toolkit/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/medeiroz/laravel-amqp-toolkit/actions?query=workflow%3Arun-tests+branch%3Amain)
@@ -8,6 +8,10 @@
 This package was developed to facilitate the integration of Laravel applications with RabbitMQ,
 providing functionalities to consume and publish messages, in addition to providing a simple way to
 manage the AMQP / RabbitMQ infrastructure through schema migrations, inspired by Laravel's database migrations.
+
+If you need to consume messages from RabbitMQ queues, publish messages in exchanges or queues, or manage the RabbitMQ infrastructure, this package is for you.
+
+If you have a problems to manage the RabbitMQ Schema same as queues, exchanges and shovels, this package is for you.
 
 ---
 
@@ -25,11 +29,12 @@ manage the AMQP / RabbitMQ infrastructure through schema migrations, inspired by
 
 
 ## Installation
-Para realizar a instalação do pacote você deve seguir os seguintes passos:
+follow the steps below to install the package:
 1. Install the `medeiroz/laravel-amqp-toolkit` package via composer
 2. Publish and run migrations
 3. Publish the configuration file
 4. Environment variables .env
+5. Configure the AMQP Queue and Laravel Listeners
 
 
 ### 1. Install the package
@@ -59,6 +64,10 @@ php artisan vendor:publish --tag="amqp-toolkit-config"
 This is the content of the published configuration file:
 
 ```php
+<?php
+
+// config for Medeiroz/AmqpToolkit
+
 return [
     'schemas' => base_path('amqp-toolkit-schemas'),
     'table_name' => env('AMQP_TABLE_NAME', 'amqp_schemas'),
@@ -78,6 +87,13 @@ return [
      */
     'logging-channel' => env('AMQP_LOG_CHANNEL', env('LOG_CHANNEL')),
 
+    /**
+     * The queues to be consumed by the consumer command without arguments.
+     */
+    'consumer-queues' => [
+        // 'payment-received' => \App\Listeners\PaymentReceivedListener::class,
+    ],
+
     'connections' => [
         'rabbitmq' => [
             'host' => env('AMQP_HOST', 'localhost'),
@@ -91,7 +107,7 @@ return [
 ];
 ```
 
-### 7. Environment variables `.env`
+### 4. Environment variables `.env`
 Edit the `.env` file and add the environment variables of your AMQP / Rabbitmq server.
 
 ```dotenv
@@ -103,6 +119,22 @@ AMQP_PASSWORD=password
 AMQP_VHOST=/
 ```
 >Remember to replace the values according to your environment.
+
+### 5. Configure the AMQP Queue and Laravel Listeners
+
+Edit the `config/amqp-toolkit.php` file and add the queues you want to consume and the listeners that will be executed when a message is received.
+
+The key of the array is the name of the queue and the value is the listener class that will be executed when a message is received.
+
+Example: Attach the listener `PaymentReceivedListener` to the queue `payment-received`
+```php
+    /**
+     * The queues to be consumed by the consumer command without arguments.
+     */
+    'consumer-queues' => [
+        'payment-received' => \App\Listeners\PaymentReceivedListener::class,
+    ],
+```
 
 Refer to the configuration file for more details.
 
@@ -148,24 +180,40 @@ php artisan amqp:migrate --refresh
 ```php
 use Medeiroz\AmqpToolkit\Facades\AmqpPublisher;
 
-AmqpPublisher::onQueue(['say' => 'hello queue'], 'my-first-queue');
-AmqpPublisher::onExchange(['say' => 'hello exchange'], 'my-exchange');
-AmqpPublisher::onExchange(['say' => 'hello exchange with routing key'], 'my-exchange', 'my-routing-key');
+AmqpPublisher::onQueue(['say' => 'Hello World'], 'my-queue-name');
+AmqpPublisher::onExchange(['say' => 'Hello World'], 'my-exchange-name');
+AmqpPublisher::onExchange(['say' => 'Hello World with routing key'], 'my-exchange-name', 'my-routing-key');
 ```
 
 ---
 
 ### Start consuming an AMQP / RabbitMQ queue
-To start consuming a specific queue you must run the artisan command below:
 
-Where `my-first-queue` is the name of the queue you want to consume.
+#### Running the consumer for all queues
+To start consuming all queues you must run the artisan command below:
+
 ```bash
-php artisan amqp:consumer my-first-queue
+php artisan amqp:consumer
+```
+
+To start consuming a specific queues you must run the artisan command below:
+
+Where `my-first-queue` and `payment-received` is the name of the queues you want to consume.
+```bash
+php artisan amqp:consumer my-first-queue payment-received
 ```
 
 ---
 
-## Listening and processing messages
+## Listening messages
+
+The package provides a way to listen to messages received from AMQP / RabbitMQ queues and exchanges, similar to Laravel's event listeners.
+
+### 1. Automatic listener registration
+
+When a queue and listener are configured in the `config/amqp-toolkit.php` file, the listener will be automatically registered when the consumer is executed.
+
+### 2. Manual listener registration
 
 Edit the `app/Providers/EventServiceProvider.php` file and add the events you want to listen to.
 
@@ -176,8 +224,8 @@ The name of the event should be `amqp.QUEUE_NAME`, where `QUEUE_NAME` is the nam
 ```php
 public function boot() {
     Event::listen(
-        'amqp:payment-received.notifications',
-        \App\Listeners\PaymentReceivedNotificationsListener::class,
+        'amqp:payment-received',
+        \App\Listeners\PaymentReceivedListener::class,
     );
     
     Event::listen(
@@ -200,7 +248,28 @@ The queue event is only called if the consumer is being executed
 You can create a listener for the event you want to listen to, for this run the command below:
 
 ```bash
-php artisan make:listener MyQueueListener
+php artisan make:listener PaymentReceivedListener
+```
+
+This package provides an event object `Medeiroz\AmqpToolkit\Events\AmqpReceivedMessageEvent` that contains the queue name and the message body.
+
+```php
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Medeiroz\AmqpToolkit\Events\AmqpReceivedMessageEvent;
+
+
+class PaymentReceivedListener
+{
+    public function handle(AmqpReceivedMessageEvent $event): void
+    {
+        \Log::debug('Queue' . $event->queue);
+        \Log::debug('Message Body', $event->messageBody);
+    }
+}
 ```
 
 If you want your events to be executed asynchronously with `Laravel Horizon`, you can use the `ShouldQueue` interface.
@@ -214,16 +283,269 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Medeiroz\AmqpToolkit\Events\AmqpReceivedMessageEvent;
 
 
-class MyQueueListeners implements ShouldQueue
-{
-    public function handle(AmqpReceivedMessageEvent $event): void
-    {
-        \Log::debug('Queue' . $event->queue);
-        \Log::debug('Message Body', $event->messageBody);
-    }
-}
+class PaymentReceivedListener implements ShouldQueue
+{ /* ... */ }
 ```
 
+## More about the AMQP Migration Schema
+
+
+### Creating an Exchange Schema
+
+Create a new exchange schema with the command below:
+```bash
+php artisan amqp:make-schema exchange my-exchange
+```
+
+Generated file:
+```php
+<?php
+
+use Medeiroz\AmqpToolkit\SchemaMigration\SchemaMigration;
+
+return new class extends SchemaMigration
+{
+    private const NAME = 'my-exchange';
+
+    public function up(): void
+    {
+        $this->createExchangeIfNonExists(self::NAME);
+    }
+
+    public function down(): void
+    {
+        $this->deleteExchangeIfExists(self::NAME);
+    }
+};
+
+```
+
+### Creating a Queue Schema
+Create a new queue schema with the command below:
+```bash
+php artisan amqp:make-schema queue payment-received
+```
+
+Generated file:
+```php
+<?php
+
+
+use Medeiroz\AmqpToolkit\SchemaMigration\SchemaMigration;
+
+return new class extends SchemaMigration
+{
+    private const NAME = 'payment-received';
+
+    public function up(): void
+    {
+        $this->createQueueIfNonExists(self::NAME)
+            ->withRetry()
+            ->withTtl(seconds: 5)
+            ->withDlq();
+    }
+
+    public function down(): void
+    {
+        $this->deleteQueueIfExists(self::NAME);
+        $this->deleteQueueIfExists(self::NAME . '.retry');
+        $this->deleteQueueIfExists(self::NAME . '.dlq');
+    }
+};
+```
+This schema creates a queue named `payment-received` with retry, ttl and dlq. RabbitMQ will automatically create the `payment-received.retry` and `payment-received.dlq` queues.
+
+You can create bind the queue to an exchange by calling the `bind` method.
+```php
+// ...
+    public function up(): void
+    {
+        $this->createQueue('my-queue')
+            ->bind('my-exchange', 'my-route-key');
+    }
+    
+    // or
+    
+    public function up(): void
+    {
+        $this->createQueue('my-queue');
+
+        $this->bind('my-queue', 'my-exchange', 'my-route-key');
+    }
+```
+
+### Creating a Shovel Schema
+Create a new shovel schema with the command below:
+```bash
+php artisan amqp:make-schema shovel my-shovel
+```
+
+Generated file:
+```php
+<?php
+
+use Medeiroz\AmqpToolkit\SchemaMigration\SchemaMigration;
+use Medeiroz\AmqpToolkit\SchemaMigration\Shovel\Resource0dot9;
+use Medeiroz\AmqpToolkit\SchemaMigration\Shovel\Resource1dot0;
+
+return new class extends SchemaMigration
+{
+    private const NAME = 'my-shovel';
+
+    public function up(): void
+    {
+        $this->createShovelIfNonExists(
+            name: self::NAME,
+            source: new Resource0dot9(
+                type: 'queue',
+                uri: 'amqp://',
+                queue: 'my-queue-on-amqp-0-9',
+                autoDelete: 'never',
+                addForwardingHeaders: 'No',
+            ),
+            destination: new Resource1dot0(
+                uri: 'amqps://user:password@my-host.servicebus.windows.net:5671/?verify=verify_none',
+                address: 'my-topic-on-service-bus',
+            ),
+        );
+    }
+
+    public function down(): void
+    {
+        $this->deleteShovelIfExists(self::NAME);
+    }
+};
+```
+You can create a shovel with the `createShovel` or `createShovelIfNonExists` method, passing the name of the shovel, the source and destination resources.
+
+The `source` and `destination` are objects that represent message `broker` resources.
+
+Available resources:
+- Resource0dot9
+  - The Message Broker resource for AMQP 0-9-1 same as RabbitMQ, Qpid, etc.
+- Resource1dot0
+  - The Message Broker resource for AMQP 1.0 same as Azure Service Bus, ActiveMQ, etc.
+
+You create a shovel to move messages from Broker A to Broker B, for example.
+- Move messages from RabbitMQ to Azure Service Bus
+- Move messages from Azure Service Bus to RabbitMQ
+- Move messages from RabbitMQ in `AWS Cloud` to RabbitMQ in `Azure Cloud`
+- Move messages from Azure Service Bus to another subscription in Azure Service Bus
+
+More about the shovel configuration can be found in the [RabbitMQ Shovel documentation](https://www.rabbitmq.com/shovel-dynamic.html).
+
+
+> Note: The shovel schema is only available for RabbitMQ 3.8.0 or later.
+
+### All available methods in schema migration
+- `createQueue(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Queue`
+  - Create a new queue
+- `createQueueIfNonExists(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Queue`
+  - Create a new queue if it does not exist
+- `deleteQueue(string $name): void`
+  - Delete a queue
+- `deleteQueueIfExists(string $name): void`
+  - Delete a queue if it exists
+- `createExchange(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Exchange`
+  - Create a new exchange
+- `createExchangeIfNonExists(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Exchange`
+  - Create a new exchange if it does not exist
+- `deleteExchange(string $name): void`
+  - Delete an exchange
+- `deleteExchangeIfExists(string $name): void`
+  - Delete an exchange if it exists
+- `bind(string $queue, string $exchange, ?string $routingKey = null): Medeiroz\AmqpToolkit\SchemaMigration\Bind`
+  - Bind a queue to an exchange with a routing key
+- `bindIfExist(string $queue, string $exchange, ?string $routingKey = null): Medeiroz\AmqpToolkit\SchemaMigration\Bind`
+  - Bind a queue to an exchange with a routing key if the queue exists
+- `unbind(string $queue, string $exchange, ?string $routingKey = null): void`
+  - Unbind a queue from an exchange with a routing key
+- `unbindIfExists(string $queue, string $exchange, ?string $routingKey = null): void`
+  - Unbind a queue from an exchange with a routing key if the queue exists
+- `createShovel(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Shovel`
+  - Create a new shovel
+- `createShovelIfNonExists(string $name): Medeiroz\AmqpToolkit\SchemaMigration\Shovel`
+  - Create a new shovel if it does not exist
+- `deleteShovel(string $name): void`
+  - Delete a shovel
+- `deleteShovelIfExists(string $name): void`
+  - Delete a shovel if it exists
+
+## More about the Shovel
+The shovel is a feature that allows you to move messages between different brokers, for example, RabbitMQ to Azure Service Bus, Azure Service Bus to RabbitMQ, etc.
+
+If your message broke is Azure Service Bus and your application as code with PHP/Laravel, you can not consume messages directly from the Azure Service Bus.
+You can create a shovel to move messages from Azure Service Bus to RabbitMQ and consume messages from RabbitMQ.
+
+> Forward message from `Azure Service Bus` to `RabbitMQ`
+
+You need create a specific resources for your shovel, for example, you have the resources below:
+- On Azure Service Bus
+  - Subscription A `(Source)`
+- On RabbitMQ
+  - Exchange `(Destination)`
+  - Queue A (for your PHP application to consume messages)
+  - Shovel "My First Shovel"
+
+```mermaid
+flowchart TD
+    subgraph "RabbitMQ"
+        E(Exchange)
+        E --> QB[Queue B]
+        E --> QA[Queue A]
+    end
+    
+    subgraph "Service Bus"
+        T(Topic)
+        T -->|Publish| SB[Subscription B]
+        T -->|Publish| SA[Subscription A]
+    end
+    
+    subgraph "Shovel Plugin"
+        S(My First Shovel) -->|Consume Messages|SA
+        S --> |Forward to| E
+    end
+    
+    subgraph "PHP consume RabbitMQ"
+        P(PHP Application) --> |Consume Messages| QA
+    end
+```
+----
+
+> Forward message from `RabbitMQ` to `Azure Service Bus`
+
+You need create a specific resources for your shovel, for example, you have the resources below:
+- On RabbitMQ
+    - Exchange
+    - Queue D `(Source)`
+    - Shovel "My Second Shovel"
+- On Azure Service Bus
+    - Topic `(Destination)`
+
+
+```mermaid
+flowchart TD
+    subgraph "RabbitMQ"
+        E(Exchange)
+        E --> QD[Queue D]
+        E --> QC[Queue C]
+    end
+
+    subgraph "Service Bus"
+        T(Topic)
+        T -->|Publish| SD[Subscription D]
+        T -->|Publish| SC[Subscription C]
+    end
+
+    subgraph "Shovel Plugin"
+        S(My Second Shovel) -->|Consume Messages|QD
+        S --> |Forward to| T
+    end
+
+    subgraph "PHP publish RabbitMQ"
+        P(PHP Application) --> |Publish Messages| E
+    end
+```
 
 ## Testing
 

--- a/config/amqp-toolkit.php
+++ b/config/amqp-toolkit.php
@@ -1,6 +1,7 @@
 <?php
 
 // config for Medeiroz/AmqpToolkit
+
 return [
     'schemas' => base_path('amqp-toolkit-schemas'),
     'table_name' => env('AMQP_TABLE_NAME', 'amqp_schemas'),
@@ -19,6 +20,13 @@ return [
      * Like as 'stack', 'single', 'daily' etc...
      */
     'logging-channel' => env('AMQP_LOG_CHANNEL', env('LOG_CHANNEL')),
+
+    /**
+     * The queues to be consumed by the consumer command without arguments.
+     */
+    'consumer-queues' => [
+        // 'payment-received.notifications' => \App\Listeners\PaymentReceivedNotificationsListener::class,
+    ],
 
     'connections' => [
         'rabbitmq' => [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/src/AmqpToolkitServiceProvider.php
+++ b/src/AmqpToolkitServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Medeiroz\AmqpToolkit;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Medeiroz\AmqpToolkit\Commands\AmqpConsumerCommand;
 use Medeiroz\AmqpToolkit\Commands\AmqpMigrateSchemaCommand;
@@ -42,6 +43,13 @@ class AmqpToolkitServiceProvider extends PackageServiceProvider
             SchemaDbRepository::class,
             fn ($app) => new SchemaDbRepository($app['db'], $app['config']['amqp-toolkit']['table_name']),
         );
+
+        $this->app->singleton(RabbitmqApi::class, function ($app) {
+            $connectionName = $app['config']['amqp-toolkit']['connection'];
+            $connection = $app['config']['amqp-toolkit']['connections'][$connectionName];
+
+            return new RabbitmqApi($connection);
+        });
 
         $this->app->bind(
             AmqpClient::class,

--- a/src/AmqpToolkitServiceProvider.php
+++ b/src/AmqpToolkitServiceProvider.php
@@ -60,4 +60,16 @@ class AmqpToolkitServiceProvider extends PackageServiceProvider
             ),
         );
     }
+
+    public function packageBooted()
+    {
+        $queues = $this->app['config']['amqp-toolkit']['consumer-queues'] ?? [];
+
+        foreach ($queues as $queue => $listener) {
+            Event::listen(
+                sprintf('amqp:%s', $queue),
+                $listener,
+            );
+        }
+    }
 }

--- a/src/AmqpToolkitServiceProvider.php
+++ b/src/AmqpToolkitServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Medeiroz\AmqpToolkit;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Medeiroz\AmqpToolkit\Commands\AmqpConsumerCommand;
 use Medeiroz\AmqpToolkit\Commands\AmqpMigrateSchemaCommand;

--- a/src/Entities/QueueInfo.php
+++ b/src/Entities/QueueInfo.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Medeiroz\AmqpToolkit\Entities;
+
+class QueueInfo
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $messageCount,
+        public readonly int $consumerCount,
+    ) {}
+}

--- a/src/RabbitmqApi.php
+++ b/src/RabbitmqApi.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Medeiroz\AmqpToolkit;
+
+use Exception;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Psr\Http\Message\ResponseInterface;
+
+class RabbitmqApi
+{
+    public function __construct(public array $connectionSettings) {}
+
+    protected function request(): PendingRequest
+    {
+        return Http::baseUrl($this->connectionSettings['host'].':'.$this->connectionSettings['api-port'])
+            ->withBasicAuth($this->connectionSettings['user'], $this->connectionSettings['password'])
+            ->throw()
+            ->withResponseMiddleware(function (ResponseInterface $response) {
+                $body = json_decode($response->getBody()->getContents(), true);
+
+                if ($body['error'] ?? false) {
+                    throw new Exception('Error rabbitmq api: '.json_encode($body));
+                }
+
+                return $response;
+            });
+    }
+
+    public function listShovels(): array
+    {
+        $vhost = urlencode($this->connectionSettings['vhost']);
+
+        return $this->request()
+            ->get("/api/shovels/$vhost")
+            ->json();
+    }
+
+    public function createShovel(string $name, array $payload): ?array
+    {
+        $payload = $this->filterAllowedProperties($payload);
+
+        $vhost = $payload['vhost'] ?? $this->connectionSettings['vhost'];
+        $vhost = urlencode($vhost);
+
+        return $this->request()
+            ->put("api/parameters/shovel/$vhost/$name", $payload)
+            ->json();
+    }
+
+    public function deleteShovel(string $name): ?array
+    {
+        $vhost = urlencode($this->connectionSettings['vhost']);
+
+        return $this->request()
+            ->delete("api/parameters/shovel/$vhost/$name")
+            ->json();
+    }
+
+    protected function filterAllowedProperties(array $payload): array
+    {
+        $whiteList = [
+            'component',
+            'vhost',
+            'name',
+            'value' => [
+                'ack-mode',
+                'reconnect-delay',
+                'src-uri',
+                'src-protocol',
+                'src-queue',
+                'src-prefetch-count',
+                'src-delete-after',
+                'src-address',
+                'src-exchange',
+                'src-exchange-key',
+                'dest-uri',
+                'dest-protocol',
+                'dest-queue',
+                'dest-add-forward-headers',
+                'dest-address',
+                'dest-exchange',
+                'dest-exchange-key',
+            ],
+        ];
+
+        $payload['value'] = Arr::only($payload['value'], $whiteList['value']);
+
+        return $payload;
+    }
+}

--- a/src/SchemaMigration/Bind.php
+++ b/src/SchemaMigration/Bind.php
@@ -5,9 +5,12 @@ namespace Medeiroz\AmqpToolkit\SchemaMigration;
 use InvalidArgumentException;
 use Medeiroz\AmqpToolkit\AmqpClient;
 use Medeiroz\AmqpToolkit\SchemaMigration\Contracts\SchemaBlueprintInterface;
+use Medeiroz\AmqpToolkit\SchemaMigration\Contracts\WithAmqpClientInterface;
 
-class Bind implements SchemaBlueprintInterface
+class Bind implements SchemaBlueprintInterface, WithAmqpClientInterface
 {
+    private ?AmqpClient $amqpClient = null;
+
     public function __construct(
         public string $action,
         public string $queue,
@@ -15,12 +18,50 @@ class Bind implements SchemaBlueprintInterface
         public string $routingKey = '',
     ) {}
 
-    public function run(AmqpClient $client): void
+    public function run(): void
     {
         match ($this->action) {
-            'bind' => $client->bind($this->queue, $this->exchange, $this->routingKey),
-            'unbind' => $client->unbind($this->queue, $this->exchange, $this->routingKey),
-            default => throw new InvalidArgumentException("Invalid action: {$this->action}"),
+            'bind' => $this->runBind(),
+            'bind-if-exists' => $this->runBindIfExists(),
+            'unbind' => $this->runUnbind(),
+            'unbind-if-exists' => $this->runUnbindIfExists(),
+            default => throw new InvalidArgumentException("Invalid action: $this->action"),
         };
+    }
+
+    public function setAmqpClient(AmqpClient $amqpClient): self
+    {
+        $this->amqpClient = $amqpClient;
+
+        return $this;
+    }
+
+    public function getAmqpClient(): AmqpClient
+    {
+        return $this->amqpClient;
+    }
+
+    public function runBind(): void
+    {
+        $this->getAmqpClient()->bind($this->queue, $this->exchange, $this->routingKey ?: '');
+    }
+
+    public function runBindIfExists(): void
+    {
+        if ($this->getAmqpClient()->queueExists($this->queue) && $this->getAmqpClient()->exchangeExists($this->exchange)) {
+            $this->runBind();
+        }
+    }
+
+    public function runUnbind(): void
+    {
+        $this->getAmqpClient()->unbind($this->queue, $this->exchange, $this->routingKey ?: '');
+    }
+
+    public function runUnbindIfExists(): void
+    {
+        if ($this->getAmqpClient()->queueExists($this->queue) && $this->getAmqpClient()->exchangeExists($this->exchange)) {
+            $this->runUnbind();
+        }
     }
 }

--- a/src/SchemaMigration/Contracts/SchemaBlueprintInterface.php
+++ b/src/SchemaMigration/Contracts/SchemaBlueprintInterface.php
@@ -2,9 +2,7 @@
 
 namespace Medeiroz\AmqpToolkit\SchemaMigration\Contracts;
 
-use Medeiroz\AmqpToolkit\AmqpClient;
-
 interface SchemaBlueprintInterface
 {
-    public function run(AmqpClient $client): void;
+    public function run(): void;
 }

--- a/src/SchemaMigration/Contracts/WithAmqpClientInterface.php
+++ b/src/SchemaMigration/Contracts/WithAmqpClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Medeiroz\AmqpToolkit\SchemaMigration\Contracts;
+
+use Medeiroz\AmqpToolkit\AmqpClient;
+
+interface WithAmqpClientInterface
+{
+    public function setAmqpClient(AmqpClient $amqpClient): self;
+
+    public function getAmqpClient(): AmqpClient;
+}

--- a/src/SchemaMigration/Contracts/WithRabbitmqApiInterface.php
+++ b/src/SchemaMigration/Contracts/WithRabbitmqApiInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Medeiroz\AmqpToolkit\SchemaMigration\Contracts;
+
+use Medeiroz\AmqpToolkit\RabbitmqApi;
+
+interface WithRabbitmqApiInterface
+{
+    public function setRabbitmqApi(RabbitmqApi $rabbitmqApi): self;
+
+    public function getRabbitmqApi(): RabbitmqApi;
+}

--- a/src/SchemaMigration/Exchange.php
+++ b/src/SchemaMigration/Exchange.php
@@ -6,21 +6,62 @@ use InvalidArgumentException;
 use Medeiroz\AmqpToolkit\AmqpClient;
 use Medeiroz\AmqpToolkit\Enums\ExchangesTypes;
 use Medeiroz\AmqpToolkit\SchemaMigration\Contracts\SchemaBlueprintInterface;
+use Medeiroz\AmqpToolkit\SchemaMigration\Contracts\WithAmqpClientInterface;
 
-class Exchange implements SchemaBlueprintInterface
+class Exchange implements SchemaBlueprintInterface, WithAmqpClientInterface
 {
+    private ?AmqpClient $amqpClient = null;
+
     public function __construct(
         public string $action,
         public string $name,
         public ExchangesTypes $type = ExchangesTypes::FANOUT,
     ) {}
 
-    public function run(AmqpClient $client): void
+    public function run(): void
     {
         match ($this->action) {
-            'create' => $client->createExchange($this->name, $this->type),
-            'delete' => $client->deleteExchange($this->name),
-            default => throw new InvalidArgumentException("Invalid action: {$this->action}"),
+            'create' => $this->runCreate(),
+            'create-if-non-exists' => $this->runCreateIfNonExists(),
+            'delete' => $this->runDelete(),
+            'delete-if-exists' => $this->runDeleteIfExists(),
+            default => throw new InvalidArgumentException("Invalid action: $this->action"),
         };
+    }
+
+    public function setAmqpClient(AmqpClient $amqpClient): self
+    {
+        $this->amqpClient = $amqpClient;
+
+        return $this;
+    }
+
+    public function getAmqpClient(): AmqpClient
+    {
+        return $this->amqpClient;
+    }
+
+    public function runCreate(): void
+    {
+        $this->getAmqpClient()->createExchange($this->name, $this->type);
+    }
+
+    public function runCreateIfNonExists(): void
+    {
+        if (! $this->getAmqpClient()->exchangeExists($this->name)) {
+            $this->runCreate();
+        }
+    }
+
+    public function runDelete(): void
+    {
+        $this->getAmqpClient()->deleteExchange($this->name);
+    }
+
+    public function runDeleteIfExists(): void
+    {
+        if ($this->getAmqpClient()->exchangeExists($this->name)) {
+            $this->runDelete();
+        }
     }
 }

--- a/src/SchemaMigration/SchemaMigration.php
+++ b/src/SchemaMigration/SchemaMigration.php
@@ -20,9 +20,23 @@ abstract class SchemaMigration
         return $exchange;
     }
 
+    public function createExchangeIfNonExists(string $name): Exchange
+    {
+        $exchange = new Exchange('create-if-non-exists', $name);
+        $this->stack[] = $exchange;
+
+        return $exchange;
+    }
+
     public function deleteExchange(string $name): void
     {
         $exchange = new Exchange('delete', $name);
+        $this->stack[] = $exchange;
+    }
+
+    public function deleteExchangeIfExists(string $name): void
+    {
+        $exchange = new Exchange('delete-if-exists', $name);
         $this->stack[] = $exchange;
     }
 
@@ -34,9 +48,23 @@ abstract class SchemaMigration
         return $queue;
     }
 
+    public function createQueueIfNonExists(string $name): Queue
+    {
+        $queue = new Queue('create-if-non-exists', $name);
+        $this->stack[] = $queue;
+
+        return $queue;
+    }
+
     public function deleteQueue(string $name): void
     {
         $queue = new Queue('delete', $name);
+        $this->stack[] = $queue;
+    }
+
+    public function deleteQueueIfExists(string $name): void
+    {
+        $queue = new Queue('delete-if-exists', $name);
         $this->stack[] = $queue;
     }
 
@@ -48,13 +76,27 @@ abstract class SchemaMigration
         return $shovel;
     }
 
+    public function createShovelIfNonExists(string $name, ResourceInterface $source, ResourceInterface $destination): Shovel
+    {
+        $shovel = new Shovel('create-if-non-exists', $name, $source, $destination);
+        $this->stack[] = $shovel;
+
+        return $shovel;
+    }
+
     public function deleteShovel(string $name): void
     {
         $shovel = new Shovel('delete', $name);
         $this->stack[] = $shovel;
     }
 
-    public function bind(string $queue, string $exchange, string $routeKey = ''): Bind
+    public function deleteShovelIfExists(string $name): void
+    {
+        $shovel = new Shovel('delete-if-exists', $name);
+        $this->stack[] = $shovel;
+    }
+
+    public function bind(string $queue, string $exchange, ?string $routeKey = null): Bind
     {
         $bind = new Bind('bind', $queue, $exchange, $routeKey);
         $this->stack[] = $bind;
@@ -62,12 +104,24 @@ abstract class SchemaMigration
         return $bind;
     }
 
-    public function unbind(string $queue, string $exchange, string $routeKey = ''): Bind
+    public function bindIfExists(string $queue, string $exchange, ?string $routeKey = null): Bind
     {
-        $bind = new Bind('unbind', $queue, $exchange, $routeKey);
+        $bind = new Bind('bind-if-exists', $queue, $exchange, $routeKey);
         $this->stack[] = $bind;
 
         return $bind;
+    }
+
+    public function unbind(string $queue, string $exchange, ?string $routeKey = null): void
+    {
+        $bind = new Bind('unbind', $queue, $exchange, $routeKey);
+        $this->stack[] = $bind;
+    }
+
+    public function unbindIfExists(string $queue, string $exchange, ?string $routeKey = null): void
+    {
+        $bind = new Bind('unbind-if-exists', $queue, $exchange, $routeKey);
+        $this->stack[] = $bind;
     }
 
     public function getStack(): array

--- a/src/stubs/amqp_schemas_create_exchange.stub
+++ b/src/stubs/amqp_schemas_create_exchange.stub
@@ -9,11 +9,11 @@ return new class extends SchemaMigration
 
     public function up(): void
     {
-        $this->createExchange(self::NAME);
+        $this->createExchangeIfNonExists(self::NAME);
     }
 
     public function down(): void
     {
-        $this->deleteExchange(self::NAME);
+        $this->deleteExchangeIfExists(self::NAME);
     }
 };

--- a/src/stubs/amqp_schemas_create_queue.stub
+++ b/src/stubs/amqp_schemas_create_queue.stub
@@ -9,7 +9,7 @@ return new class extends SchemaMigration
 
     public function up(): void
     {
-        $this->createQueue(self::NAME)
+        $this->createQueueIfNonExists(self::NAME)
             ->withRetry()
             ->withTtl(seconds: 5)
             ->withDlq();
@@ -17,8 +17,8 @@ return new class extends SchemaMigration
 
     public function down(): void
     {
-        $this->deleteQueue(self::NAME);
-        $this->deleteQueue(self::NAME . '.retry');
-        $this->deleteQueue(self::NAME . '.dlq');
+        $this->deleteQueueIfExists(self::NAME);
+        $this->deleteQueueIfExists(self::NAME . '.retry');
+        $this->deleteQueueIfExists(self::NAME . '.dlq');
     }
 };

--- a/src/stubs/amqp_schemas_create_shovel.stub
+++ b/src/stubs/amqp_schemas_create_shovel.stub
@@ -11,7 +11,7 @@ return new class extends SchemaMigration
 
     public function up(): void
     {
-        $this->createShovel(
+        $this->createShovelIfNonExists(
             name: self::NAME,
             source: new Resource0dot9(
                 type: 'queue',
@@ -29,6 +29,6 @@ return new class extends SchemaMigration
 
     public function down(): void
     {
-        $this->deleteShovel(self::NAME);
+        $this->deleteShovelIfExists(self::NAME);
     }
 };


### PR DESCRIPTION
**Added the features:**
- consume multiples queues in single command
   - php artisan amqp:consume my-queue queue-b
- auto bind/listener the queues events
   - the amqp-toolkit.php > consumer-queues
- migrations schemas
    - create if non exists
    - delete if exists
    - for all schemas types


**Multiples refactories**